### PR TITLE
Clarifying the license in the Readme

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ Version
 
 License
 =======
-BSD
+BSD-4-Clause
 
 Changelog
 ==========


### PR DESCRIPTION
"BSD" should not be used as a license identifier, as it's too unspecific. 
It is important to be specific about the "kind of BSD license" used, as their terms vary and the BSD-4-clause e.g. should not be combined with GPL licensed software.

I suggest to use the SPDX identifier, see  https://spdx.org/licenses/.
